### PR TITLE
Use byte count, not string length, to determine content-length

### DIFF
--- a/OwinFriendlyExceptions/OwinFriendlyExceptionsMiddleware.cs
+++ b/OwinFriendlyExceptions/OwinFriendlyExceptionsMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 
@@ -74,7 +75,7 @@ namespace OwinFriendlyExceptions
             context.Response.ContentType = transform.ContentType;
             context.Response.StatusCode = (int) transform.StatusCode;
             context.Response.ReasonPhrase = transform.ReasonPhrase;
-            context.Response.ContentLength = content.Length;
+	        context.Response.ContentLength = Encoding.UTF8.GetByteCount(content);
             await context.Response.WriteAsync(content);
         }
 


### PR DESCRIPTION
When `content` returned from the middleware contains non-ASCII chars, byte count does not equal string length. This results in truncation of the returned content. This PR addresses this issue. Thanks for a otherwise awesome util.
